### PR TITLE
Nwkaddr update

### DIFF
--- a/lib/components/controller.js
+++ b/lib/components/controller.js
@@ -577,9 +577,14 @@ Controller.prototype.endDeviceAnnceHdlr = function (data) {
         joinEvent = 'ind:incoming' + ':' + data.ieeeaddr,
         dev = this._shepherd._findDevByAddr(data.ieeeaddr);
 
-    if (dev && dev.status === 'online'){  // Device has already joined, do next item in queue
-        debug.shepherd(`Device: ${dev.getIeeeAddr()} already in network`);
+    if (dev && dev.status === 'online') {
+        if (data.nwkaddr && dev.getNwkAddr() !== data.nwkaddr) {
+            debug.shepherd(`Device: ${dev.getIeeeAddr()} got new nwkAddr ${data.nwkaddr}, old was ${dev.getNwkAddr()}`);
+            dev.update({ nwkAddr: data.nwkaddr });
+        }
 
+        debug.shepherd(`Device: ${dev.getIeeeAddr()} already in network`);
+        // Device has already joined, do next item in queue
         if (self._joinQueue.length) {
             var next = self._joinQueue.shift();
 


### PR DESCRIPTION
Some enddevices frequently change there parent (Philips). In some of this cases, they get a new nwkAddr assigned.
Seems this change was not handled yet, so shepherd still used the old address, resulting in device not being reachable anymore (until adapter restart).

Tested this change since some days, my philips motion sensor (sml001) works far better now.